### PR TITLE
feat: add unit/integration tests and profile management commands

### DIFF
--- a/command/profile.go
+++ b/command/profile.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Koutaro-Hanabusa/mangrove"
 	"github.com/spf13/cobra"
@@ -86,8 +89,215 @@ var profileShowCmd = &cobra.Command{
 	},
 }
 
+var profileAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new profile",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(os.Stdin)
+
+		// Prompt for profile name
+		var profileName string
+		for profileName == "" {
+			profileName = promptInput(reader, "Profile name", "")
+			if profileName == "" {
+				fmt.Fprintln(os.Stderr, "  Profile name is required.")
+			}
+		}
+
+		// Check if already exists
+		if _, ok := cfg.Profiles[profileName]; ok {
+			return fmt.Errorf("profile %q already exists", profileName)
+		}
+
+		if !mangrove.IsFzfAvailable() {
+			return fmt.Errorf("fzf is required for repository selection. Install it with: brew install fzf")
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+
+		// Loop to add repos
+		var repos []mangrove.Repo
+		for {
+			fmt.Fprintln(os.Stderr, "? Select repository directory (Esc to finish):")
+			repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+			if err != nil {
+				if strings.Contains(err.Error(), "cancelled") {
+					if len(repos) == 0 {
+						fmt.Fprintln(os.Stderr, "  At least one repository is required.")
+						continue
+					}
+					break
+				}
+				return fmt.Errorf("directory selection failed: %w", err)
+			}
+
+			expandedPath := mangrove.ExpandPath(repoPath)
+			if !isGitRepo(expandedPath) {
+				fmt.Fprintf(os.Stderr, "  %s is not a valid git repository.\n", expandedPath)
+				continue
+			}
+
+			repoName := filepath.Base(expandedPath)
+			detectedBranch := mangrove.DetectDefaultBranch(expandedPath)
+			fmt.Fprintf(os.Stderr, "  -> Detected: %s (branch: %s)\n", repoName, detectedBranch)
+
+			defaultBase := promptInput(reader, "Default base branch", detectedBranch)
+			if defaultBase == "" {
+				defaultBase = detectedBranch
+			}
+
+			repos = append(repos, mangrove.Repo{
+				Name:        repoName,
+				Path:        expandedPath,
+				DefaultBase: defaultBase,
+			})
+
+			fmt.Fprint(os.Stderr, "? Add another repository? (Y/n): ")
+			if !promptYesNo(reader, true) {
+				break
+			}
+		}
+
+		if len(repos) == 0 {
+			return fmt.Errorf("no repositories added, aborting")
+		}
+
+		profile := mangrove.Profile{Repos: repos}
+		if err := cfg.AddProfile(profileName, profile); err != nil {
+			return err
+		}
+
+		// Ask to set as default
+		fmt.Fprint(os.Stderr, "? Set as default profile? (y/N): ")
+		if promptYesNo(reader, false) {
+			cfg.DefaultProfile = profileName
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Profile %q added with %d repos", profileName, len(repos))
+		return nil
+	},
+}
+
+var profileAddRepoCmd = &cobra.Command{
+	Use:   "add-repo [profile-name]",
+	Short: "Add a repository to a profile",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(os.Stdin)
+
+		var profileName string
+		if len(args) > 0 {
+			profileName = args[0]
+		} else {
+			_, name, err := resolveProfile(true)
+			if err != nil {
+				return err
+			}
+			profileName = name
+		}
+
+		// Verify profile exists
+		if _, ok := cfg.Profiles[profileName]; !ok {
+			return fmt.Errorf("profile %q not found", profileName)
+		}
+
+		if !mangrove.IsFzfAvailable() {
+			return fmt.Errorf("fzf is required. Install it with: brew install fzf")
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+
+		fmt.Fprintln(os.Stderr, "? Select repository directory:")
+		repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+		if err != nil {
+			return fmt.Errorf("directory selection failed: %w", err)
+		}
+
+		expandedPath := mangrove.ExpandPath(repoPath)
+		if !isGitRepo(expandedPath) {
+			return fmt.Errorf("%s is not a valid git repository", expandedPath)
+		}
+
+		repoName := filepath.Base(expandedPath)
+		detectedBranch := mangrove.DetectDefaultBranch(expandedPath)
+		fmt.Fprintf(os.Stderr, "  -> Detected: %s (branch: %s)\n", repoName, detectedBranch)
+
+		defaultBase := promptInput(reader, "Default base branch", detectedBranch)
+		if defaultBase == "" {
+			defaultBase = detectedBranch
+		}
+
+		repo := mangrove.Repo{
+			Name:        repoName,
+			Path:        expandedPath,
+			DefaultBase: defaultBase,
+		}
+
+		if err := cfg.AddRepoToProfile(profileName, repo); err != nil {
+			return err
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Added %s to profile %q", repoName, profileName)
+		return nil
+	},
+}
+
+var profileRemoveRepoCmd = &cobra.Command{
+	Use:   "remove-repo [profile-name] [repo-name]",
+	Short: "Remove a repository from a profile",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var profileName, repoName string
+
+		if len(args) == 2 {
+			profileName = args[0]
+			repoName = args[1]
+		} else if len(args) == 1 {
+			if profileFlag != "" {
+				profileName = profileFlag
+				repoName = args[0]
+			} else {
+				_, name, err := resolveProfile(true)
+				if err != nil {
+					return err
+				}
+				profileName = name
+				repoName = args[0]
+			}
+		}
+
+		if err := cfg.RemoveRepoFromProfile(profileName, repoName); err != nil {
+			return err
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Removed %s from profile %q", repoName, profileName)
+		return nil
+	},
+}
+
 func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileShowCmd)
+	profileCmd.AddCommand(profileAddCmd)
+	profileCmd.AddCommand(profileAddRepoCmd)
+	profileCmd.AddCommand(profileRemoveRepoCmd)
 	rootCmd.AddCommand(profileCmd)
 }

--- a/config.go
+++ b/config.go
@@ -200,6 +200,58 @@ func (c *Config) ProfileNames() []string {
 	return names
 }
 
+// AddProfile adds a new profile to the config.
+// Returns an error if a profile with the same name already exists.
+func (c *Config) AddProfile(name string, profile Profile) error {
+	if _, ok := c.Profiles[name]; ok {
+		return fmt.Errorf("profile %q already exists", name)
+	}
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]Profile)
+	}
+	c.Profiles[name] = profile
+	return nil
+}
+
+// AddRepoToProfile adds a repository to an existing profile.
+// Returns an error if the profile does not exist or a repo with the same name already exists.
+func (c *Config) AddRepoToProfile(profileName string, repo Repo) error {
+	profile, ok := c.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	for _, r := range profile.Repos {
+		if r.Name == repo.Name {
+			return fmt.Errorf("repository %q already exists in profile %q", repo.Name, profileName)
+		}
+	}
+	profile.Repos = append(profile.Repos, repo)
+	c.Profiles[profileName] = profile
+	return nil
+}
+
+// RemoveRepoFromProfile removes a repository from an existing profile.
+// Returns an error if the profile or repository does not exist.
+func (c *Config) RemoveRepoFromProfile(profileName, repoName string) error {
+	profile, ok := c.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	idx := -1
+	for i, r := range profile.Repos {
+		if r.Name == repoName {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("repository %q not found in profile %q", repoName, profileName)
+	}
+	profile.Repos = append(profile.Repos[:idx], profile.Repos[idx+1:]...)
+	c.Profiles[profileName] = profile
+	return nil
+}
+
 // GetRepoDefaultBase returns the default base branch for a repo,
 // falling back to "main" if not set.
 func (r *Repo) GetDefaultBase() string {

--- a/config_integration_test.go
+++ b/config_integration_test.go
@@ -1,0 +1,130 @@
+package mangrove
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	viper.Reset()
+
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg := Config{
+		BaseDir:        filepath.Join(tmpDir, "workspaces"),
+		DefaultProfile: "test",
+		Profiles: map[string]Profile{
+			"test": {
+				Repos: []Repo{
+					{
+						Name:        "app",
+						Path:        filepath.Join(tmpDir, "repos", "app"),
+						DefaultBase: "main",
+					},
+					{
+						Name:        "lib",
+						Path:        filepath.Join(tmpDir, "repos", "lib"),
+						DefaultBase: "develop",
+					},
+				},
+				Hooks: Hooks{
+					PostCreate: []Hook{
+						{Repo: "app", Run: "make setup"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := SaveConfig(&cfg); err != nil {
+		t.Fatalf("SaveConfig() error: %v", err)
+	}
+
+	// Verify the config file was created
+	configPath := filepath.Join(tmpDir, ".config", "mgv", "config.yaml")
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config file not created at %s: %v", configPath, err)
+	}
+
+	// Reset viper before loading to clear global state
+	viper.Reset()
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+
+	// BaseDir should be expanded back to the absolute path
+	if loaded.BaseDir != cfg.BaseDir {
+		t.Errorf("BaseDir = %q, want %q", loaded.BaseDir, cfg.BaseDir)
+	}
+
+	if loaded.DefaultProfile != cfg.DefaultProfile {
+		t.Errorf("DefaultProfile = %q, want %q", loaded.DefaultProfile, cfg.DefaultProfile)
+	}
+
+	if len(loaded.Profiles) != len(cfg.Profiles) {
+		t.Fatalf("Profiles count = %d, want %d", len(loaded.Profiles), len(cfg.Profiles))
+	}
+
+	testProfile, ok := loaded.Profiles["test"]
+	if !ok {
+		t.Fatal("profile 'test' not found in loaded config")
+	}
+
+	if len(testProfile.Repos) != 2 {
+		t.Fatalf("Repos count = %d, want 2", len(testProfile.Repos))
+	}
+
+	// Verify repos have expanded paths
+	for i, repo := range testProfile.Repos {
+		wantRepo := cfg.Profiles["test"].Repos[i]
+		if repo.Name != wantRepo.Name {
+			t.Errorf("Repo[%d].Name = %q, want %q", i, repo.Name, wantRepo.Name)
+		}
+		if repo.Path != wantRepo.Path {
+			t.Errorf("Repo[%d].Path = %q, want %q", i, repo.Path, wantRepo.Path)
+		}
+		if repo.DefaultBase != wantRepo.DefaultBase {
+			t.Errorf("Repo[%d].DefaultBase = %q, want %q", i, repo.DefaultBase, wantRepo.DefaultBase)
+		}
+	}
+
+	// Verify hooks survived round-trip
+	if len(testProfile.Hooks.PostCreate) != 1 {
+		t.Fatalf("PostCreate hooks count = %d, want 1", len(testProfile.Hooks.PostCreate))
+	}
+	hook := testProfile.Hooks.PostCreate[0]
+	if hook.Repo != "app" || hook.Run != "make setup" {
+		t.Errorf("Hook = {Repo:%q, Run:%q}, want {Repo:\"app\", Run:\"make setup\"}", hook.Repo, hook.Run)
+	}
+}
+
+func TestDetectDefaultBranch(t *testing.T) {
+	t.Run("gitリポジトリなしはmainにフォールバック", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		got := DetectDefaultBranch(tmpDir)
+		if got != "main" {
+			t.Errorf("DetectDefaultBranch(non-repo) = %q, want \"main\"", got)
+		}
+	})
+
+	t.Run("リモート未設定のリポジトリはmainにフォールバック", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cmd := exec.Command("git", "init", tmpDir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init failed: %s: %v", out, err)
+		}
+
+		got := DetectDefaultBranch(tmpDir)
+		if got != "main" {
+			t.Errorf("DetectDefaultBranch(no-remote) = %q, want \"main\"", got)
+		}
+	})
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,308 @@
+package mangrove
+
+import (
+	"os"
+	"sort"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"チルダ付きサブディレクトリを展開", "~/Documents", home + "/Documents"},
+		{"絶対パスはそのまま", "/absolute/path", "/absolute/path"},
+		{"相対パスはそのまま", "relative/path", "relative/path"},
+		{"空文字列はそのまま", "", ""},
+		{"チルダの後にスラッシュなしはそのまま", "~notslash", "~notslash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandPath(tt.path)
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollapsePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"ホーム配下のパスをチルダ形式に変換", home + "/Documents", "~/Documents"},
+		{"ホーム外のパスはそのまま", "/other/path", "/other/path"},
+		{"ホームディレクトリ自体はチルダに変換", home, "~"},
+		{"空文字列はそのまま", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CollapsePath(tt.path)
+			if got != tt.want {
+				t.Errorf("CollapsePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetProfile(t *testing.T) {
+	cfg := &Config{
+		DefaultProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Repos: []Repo{{Name: "repo1", Path: "/path/to/repo1"}},
+			},
+			"work": {
+				Repos: []Repo{{Name: "repo2", Path: "/path/to/repo2"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		profileName string
+		wantName    string
+		wantErr     bool
+	}{
+		{"名前指定で既存プロファイルを取得", "work", "work", false},
+		{"存在しないプロファイルはエラー", "missing", "", true},
+		{"空名はデフォルトプロファイルを使用", "", "default", false},
+		{"デフォルト未設定で空名はエラー", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := cfg
+			if tt.name == "デフォルト未設定で空名はエラー" {
+				c = &Config{
+					DefaultProfile: "",
+					Profiles:       map[string]Profile{},
+				}
+			}
+
+			profile, name, err := c.GetProfile(tt.profileName)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetProfile(%q) expected error, got nil", tt.profileName)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("GetProfile(%q) unexpected error: %v", tt.profileName, err)
+				return
+			}
+			if name != tt.wantName {
+				t.Errorf("GetProfile(%q) name = %q, want %q", tt.profileName, name, tt.wantName)
+			}
+			if profile == nil {
+				t.Errorf("GetProfile(%q) returned nil profile", tt.profileName)
+			}
+		})
+	}
+}
+
+func TestProfileNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles map[string]Profile
+		want     []string
+	}{
+		{
+			"複数プロファイルの名前一覧を取得",
+			map[string]Profile{
+				"alpha": {},
+				"beta":  {},
+				"gamma": {},
+			},
+			[]string{"alpha", "beta", "gamma"},
+		},
+		{
+			"プロファイルなしは空スライス",
+			map[string]Profile{},
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Profiles: tt.profiles}
+			got := cfg.ProfileNames()
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if len(got) != len(tt.want) {
+				t.Errorf("ProfileNames() returned %d names, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ProfileNames()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetDefaultBase(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultBase string
+		want        string
+	}{
+		{"カスタムベースブランチを返す", "develop", "develop"},
+		{"未設定時はmainにフォールバック", "", "main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Repo{DefaultBase: tt.defaultBase}
+			got := r.GetDefaultBase()
+			if got != tt.want {
+				t.Errorf("GetDefaultBase() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   map[string]Profile
+		addName string
+		wantErr bool
+	}{
+		{"新しいプロファイルを正常に追加", map[string]Profile{}, "new-profile", false},
+		{"既存プロファイル名はエラー", map[string]Profile{"existing": {}}, "existing", true},
+		{"nilマップでも正常に追加", nil, "first", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Profiles: tt.setup}
+			err := cfg.AddProfile(tt.addName, Profile{})
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("AddProfile(%q) expected error, got nil", tt.addName)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("AddProfile(%q) unexpected error: %v", tt.addName, err)
+				return
+			}
+			if _, ok := cfg.Profiles[tt.addName]; !ok {
+				t.Errorf("AddProfile(%q) profile not found after adding", tt.addName)
+			}
+		})
+	}
+}
+
+func TestAddRepoToProfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		repo        Repo
+		wantErr     bool
+	}{
+		{"リポジトリを正常に追加", "dev", Repo{Name: "new-repo", Path: "/path"}, false},
+		{"存在しないプロファイルはエラー", "nonexistent", Repo{Name: "repo"}, true},
+		{"同名リポジトリの重複はエラー", "dev", Repo{Name: "existing-repo"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Profiles: map[string]Profile{
+					"dev": {
+						Repos: []Repo{{Name: "existing-repo", Path: "/existing"}},
+					},
+				},
+			}
+			err := cfg.AddRepoToProfile(tt.profileName, tt.repo)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("AddRepoToProfile(%q, %q) expected error, got nil", tt.profileName, tt.repo.Name)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("AddRepoToProfile(%q, %q) unexpected error: %v", tt.profileName, tt.repo.Name, err)
+				return
+			}
+			profile := cfg.Profiles[tt.profileName]
+			found := false
+			for _, r := range profile.Repos {
+				if r.Name == tt.repo.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("AddRepoToProfile(%q, %q) repo not found after adding", tt.profileName, tt.repo.Name)
+			}
+		})
+	}
+}
+
+func TestRemoveRepoFromProfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		repoName    string
+		wantErr     bool
+	}{
+		{"リポジトリを正常に削除", "dev", "repo1", false},
+		{"存在しないプロファイルはエラー", "nonexistent", "repo1", true},
+		{"存在しないリポジトリはエラー", "dev", "nonexistent", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Profiles: map[string]Profile{
+					"dev": {
+						Repos: []Repo{
+							{Name: "repo1", Path: "/path/repo1"},
+							{Name: "repo2", Path: "/path/repo2"},
+						},
+					},
+				},
+			}
+			err := cfg.RemoveRepoFromProfile(tt.profileName, tt.repoName)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("RemoveRepoFromProfile(%q, %q) expected error, got nil", tt.profileName, tt.repoName)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("RemoveRepoFromProfile(%q, %q) unexpected error: %v", tt.profileName, tt.repoName, err)
+				return
+			}
+			profile := cfg.Profiles[tt.profileName]
+			if len(profile.Repos) != 1 {
+				t.Errorf("RemoveRepoFromProfile(%q, %q) expected 1 repo remaining, got %d", tt.profileName, tt.repoName, len(profile.Repos))
+			}
+			for _, r := range profile.Repos {
+				if r.Name == tt.repoName {
+					t.Errorf("RemoveRepoFromProfile(%q, %q) repo still present after removal", tt.profileName, tt.repoName)
+				}
+			}
+		})
+	}
+}

--- a/fzf_test.go
+++ b/fzf_test.go
@@ -1,0 +1,31 @@
+package mangrove
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReorderWithDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []string
+		defaultItem string
+		expect      []string
+	}{
+		{"デフォルト項目を先頭に移動", []string{"a", "b", "c"}, "b", []string{"b", "a", "c"}},
+		{"既に先頭の場合は順序維持", []string{"a", "b", "c"}, "a", []string{"a", "b", "c"}},
+		{"存在しない項目は順序変更なし", []string{"a", "b", "c"}, "z", []string{"a", "b", "c"}},
+		{"デフォルト空文字はそのまま返す", []string{"a", "b", "c"}, "", []string{"a", "b", "c"}},
+		{"空リストは空リストを返す", []string{}, "a", []string{}},
+		{"要素1つでも正しく処理", []string{"single"}, "single", []string{"single"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reorderWithDefault(tt.items, tt.defaultItem)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("reorderWithDefault(%v, %q) = %v, want %v", tt.items, tt.defaultItem, got, tt.expect)
+			}
+		})
+	}
+}

--- a/git_integration_test.go
+++ b/git_integration_test.go
@@ -1,0 +1,237 @@
+package mangrove
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initTestRepo creates a temporary git repository with an initial commit on "main".
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %s: %v", args, out, err)
+		}
+	}
+	run("init")
+	run("checkout", "-b", "main")
+	// create initial commit
+	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test"), 0644)
+	run("add", ".")
+	run("commit", "-m", "initial commit")
+	return dir
+}
+
+func TestCurrentBranch(t *testing.T) {
+	repo := initTestRepo(t)
+
+	t.Run("デフォルトブランチはmain", func(t *testing.T) {
+		branch, err := CurrentBranch(repo)
+		if err != nil {
+			t.Fatalf("CurrentBranch failed: %v", err)
+		}
+		if branch != "main" {
+			t.Errorf("got %q, want %q", branch, "main")
+		}
+	})
+
+	t.Run("チェックアウト後は新ブランチ名を返す", func(t *testing.T) {
+		cmd := exec.Command("git", "-C", repo, "checkout", "-b", "develop")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git checkout -b develop failed: %s: %v", out, err)
+		}
+
+		branch, err := CurrentBranch(repo)
+		if err != nil {
+			t.Fatalf("CurrentBranch failed: %v", err)
+		}
+		if branch != "develop" {
+			t.Errorf("got %q, want %q", branch, "develop")
+		}
+	})
+}
+
+func TestBranchList(t *testing.T) {
+	repo := initTestRepo(t)
+
+	t.Run("mainブランチが含まれる", func(t *testing.T) {
+		branches, err := BranchList(repo)
+		if err != nil {
+			t.Fatalf("BranchList failed: %v", err)
+		}
+		if !contains(branches, "main") {
+			t.Errorf("expected branches to contain %q, got %v", "main", branches)
+		}
+	})
+
+	t.Run("作成したブランチが一覧に含まれる", func(t *testing.T) {
+		cmd := exec.Command("git", "-C", repo, "branch", "feature")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch feature failed: %s: %v", out, err)
+		}
+
+		branches, err := BranchList(repo)
+		if err != nil {
+			t.Fatalf("BranchList failed: %v", err)
+		}
+		if !contains(branches, "main") {
+			t.Errorf("expected branches to contain %q, got %v", "main", branches)
+		}
+		if !contains(branches, "feature") {
+			t.Errorf("expected branches to contain %q, got %v", "feature", branches)
+		}
+	})
+}
+
+func TestStatusPorcelain(t *testing.T) {
+	repo := initTestRepo(t)
+
+	t.Run("クリーンなリポジトリは空文字列", func(t *testing.T) {
+		status, err := StatusPorcelain(repo)
+		if err != nil {
+			t.Fatalf("StatusPorcelain failed: %v", err)
+		}
+		if status != "" {
+			t.Errorf("expected empty status for clean repo, got %q", status)
+		}
+	})
+
+	t.Run("未追跡ファイルは??で表示", func(t *testing.T) {
+		os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("hello"), 0644)
+
+		status, err := StatusPorcelain(repo)
+		if err != nil {
+			t.Fatalf("StatusPorcelain failed: %v", err)
+		}
+		if !strings.Contains(status, "??") {
+			t.Errorf("expected status to contain %q, got %q", "??", status)
+		}
+	})
+}
+
+func TestStatusChangedCount(t *testing.T) {
+	repo := initTestRepo(t)
+
+	t.Run("クリーンなリポジトリは0件", func(t *testing.T) {
+		count, err := StatusChangedCount(repo)
+		if err != nil {
+			t.Fatalf("StatusChangedCount failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("未追跡ファイル1つで1件", func(t *testing.T) {
+		os.WriteFile(filepath.Join(repo, "file1.txt"), []byte("a"), 0644)
+
+		count, err := StatusChangedCount(repo)
+		if err != nil {
+			t.Fatalf("StatusChangedCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1, got %d", count)
+		}
+	})
+
+	t.Run("未追跡ファイル2つで2件", func(t *testing.T) {
+		os.WriteFile(filepath.Join(repo, "file2.txt"), []byte("b"), 0644)
+
+		count, err := StatusChangedCount(repo)
+		if err != nil {
+			t.Fatalf("StatusChangedCount failed: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("expected 2, got %d", count)
+		}
+	})
+}
+
+func TestWorktreeLifecycle(t *testing.T) {
+	repo := initTestRepo(t)
+	wtDir := filepath.Join(t.TempDir(), "wt")
+
+	// Resolve symlinks so paths match git's resolved output (macOS /var -> /private/var).
+	resolvedWtDir := wtDir
+	if resolved, err := filepath.EvalSymlinks(filepath.Dir(wtDir)); err == nil {
+		resolvedWtDir = filepath.Join(resolved, "wt")
+	}
+
+	// Step 1: Add worktree
+	err := WorktreeAdd(repo, wtDir, "feature", "main")
+	if err != nil {
+		t.Fatalf("WorktreeAdd failed: %v", err)
+	}
+
+	// Step 2: Verify worktree directory exists
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Fatal("worktree directory was not created")
+	}
+
+	// Step 3: WorktreeList should include the new worktree
+	entries, err := WorktreeList(repo)
+	if err != nil {
+		t.Fatalf("WorktreeList failed: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Worktree == resolvedWtDir {
+			found = true
+			if e.Branch != "refs/heads/feature" {
+				t.Errorf("expected branch %q, got %q", "refs/heads/feature", e.Branch)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("worktree %q not found in list: %+v", resolvedWtDir, entries)
+	}
+
+	// Step 4: CurrentBranch on worktree should return "feature"
+	branch, err := CurrentBranch(wtDir)
+	if err != nil {
+		t.Fatalf("CurrentBranch on worktree failed: %v", err)
+	}
+	if branch != "feature" {
+		t.Errorf("expected branch %q, got %q", "feature", branch)
+	}
+
+	// Step 5: Remove worktree
+	err = WorktreeRemove(repo, wtDir, false)
+	if err != nil {
+		t.Fatalf("WorktreeRemove failed: %v", err)
+	}
+
+	// Step 6: WorktreeList should no longer include the removed worktree
+	entries, err = WorktreeList(repo)
+	if err != nil {
+		t.Fatalf("WorktreeList after remove failed: %v", err)
+	}
+	for _, e := range entries {
+		if e.Worktree == resolvedWtDir {
+			t.Errorf("worktree %q should have been removed but still in list", resolvedWtDir)
+		}
+	}
+}
+
+// contains checks if a string slice contains a given value.
+func contains(ss []string, target string) bool {
+	for _, s := range ss {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,31 @@
+package mangrove
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseLines(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{
+		{"空入力はnil", "", nil},
+		{"1行のみ", "hello", []string{"hello"}},
+		{"複数行の分割", "a\nb\nc", []string{"a", "b", "c"}},
+		{"空行を除外", "a\n\nb\n\nc", []string{"a", "b", "c"}},
+		{"前後の空白をトリム", "  a  \n  b  ", []string{"a", "b"}},
+		{"末尾改行を処理", "a\n", []string{"a"}},
+		{"全て空行はnil", "\n\n\n", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLines(tt.input)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("parseLines(%q) = %v, want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}

--- a/ui_test.go
+++ b/ui_test.go
@@ -1,0 +1,27 @@
+package mangrove
+
+import (
+	"testing"
+)
+
+func TestJoinParts(t *testing.T) {
+	tests := []struct {
+		name   string
+		parts  []string
+		expect string
+	}{
+		{"空スライスは空文字列", []string{}, ""},
+		{"要素1つはそのまま返す", []string{"ahead"}, "ahead"},
+		{"要素2つをandで結合", []string{"ahead", "behind"}, "ahead and behind"},
+		{"要素3つ目以降は無視される", []string{"a", "b", "c"}, "a and b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := joinParts(tt.parts)
+			if got != tt.expect {
+				t.Errorf("joinParts(%v) = %q, want %q", tt.parts, got, tt.expect)
+			}
+		})
+	}
+}

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,0 +1,194 @@
+package mangrove
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetWorkspacePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDir     string
+		profileName string
+		wsName      string
+		want        string
+	}{
+		{
+			name:        "標準的なパス組み立て",
+			baseDir:     "/base",
+			profileName: "dev",
+			wsName:      "feature",
+			want:        filepath.Join("/base", "dev", "feature"),
+		},
+		{
+			name:        "プロファイル名が空の場合",
+			baseDir:     "/base",
+			profileName: "",
+			wsName:      "ws",
+			want:        filepath.Join("/base", "ws"),
+		},
+		{
+			name:        "ワークスペース名が空の場合",
+			baseDir:     "/base",
+			profileName: "p",
+			wsName:      "",
+			want:        filepath.Join("/base", "p"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{BaseDir: tt.baseDir}
+			got := GetWorkspacePath(cfg, tt.profileName, tt.wsName)
+			if got != tt.want {
+				t.Errorf("GetWorkspacePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceLabels(t *testing.T) {
+	t.Run("クリーンなリポジトリのラベル生成", func(t *testing.T) {
+		workspaces := []WorkspaceInfo{
+			{
+				ProfileName:   "dev",
+				WorkspaceName: "feature-1",
+				Path:          "/base/dev/feature-1",
+				RepoStatuses: []RepoStatus{
+					{RepoName: "api", ChangedCount: 0, Exists: true},
+				},
+			},
+		}
+
+		labels := WorkspaceLabels(workspaces)
+		if len(labels) != 1 {
+			t.Fatalf("expected 1 label, got %d", len(labels))
+		}
+		if !strings.HasPrefix(labels[0], "dev/feature-1") {
+			t.Errorf("label should start with %q, got %q", "dev/feature-1", labels[0])
+		}
+		if !strings.Contains(labels[0], "api") {
+			t.Errorf("label should contain repo name %q, got %q", "api", labels[0])
+		}
+	})
+
+	t.Run("変更ありリポジトリのラベル生成", func(t *testing.T) {
+		workspaces := []WorkspaceInfo{
+			{
+				ProfileName:   "dev",
+				WorkspaceName: "feature-2",
+				Path:          "/base/dev/feature-2",
+				RepoStatuses: []RepoStatus{
+					{RepoName: "web", ChangedCount: 3, Exists: true},
+				},
+			},
+		}
+
+		labels := WorkspaceLabels(workspaces)
+		if len(labels) != 1 {
+			t.Fatalf("expected 1 label, got %d", len(labels))
+		}
+		if !strings.HasPrefix(labels[0], "dev/feature-2") {
+			t.Errorf("label should start with %q, got %q", "dev/feature-2", labels[0])
+		}
+		if !strings.Contains(labels[0], "web") {
+			t.Errorf("label should contain repo name %q, got %q", "web", labels[0])
+		}
+	})
+
+	t.Run("存在しないリポジトリはmissing表示", func(t *testing.T) {
+		workspaces := []WorkspaceInfo{
+			{
+				ProfileName:   "prod",
+				WorkspaceName: "hotfix",
+				Path:          "/base/prod/hotfix",
+				RepoStatuses: []RepoStatus{
+					{RepoName: "backend", Exists: false},
+				},
+			},
+		}
+
+		labels := WorkspaceLabels(workspaces)
+		if len(labels) != 1 {
+			t.Fatalf("expected 1 label, got %d", len(labels))
+		}
+		if !strings.HasPrefix(labels[0], "prod/hotfix") {
+			t.Errorf("label should start with %q, got %q", "prod/hotfix", labels[0])
+		}
+		if !strings.Contains(labels[0], "missing") {
+			t.Errorf("label should contain %q for non-existing repo, got %q", "missing", labels[0])
+		}
+	})
+
+	t.Run("空のワークスペースリストは空ラベル", func(t *testing.T) {
+		labels := WorkspaceLabels([]WorkspaceInfo{})
+		if len(labels) != 0 {
+			t.Errorf("expected 0 labels, got %d", len(labels))
+		}
+	})
+}
+
+func TestParseWorkspaceLabel(t *testing.T) {
+	tests := []struct {
+		name          string
+		label         string
+		wantProfile   string
+		wantWorkspace string
+		wantErr       bool
+	}{
+		{
+			name:          "ステータス付きラベルのパース",
+			label:         "dev/feature-1     [repo: \u2713 clean]",
+			wantProfile:   "dev",
+			wantWorkspace: "feature-1",
+			wantErr:       false,
+		},
+		{
+			name:          "ステータスなしラベルのパース",
+			label:         "prod/hotfix",
+			wantProfile:   "prod",
+			wantWorkspace: "hotfix",
+			wantErr:       false,
+		},
+		{
+			name:    "スラッシュなしはエラー",
+			label:   "noslash",
+			wantErr: true,
+		},
+		{
+			name:    "空ラベルはエラー",
+			label:   "",
+			wantErr: true,
+		},
+		{
+			name:          "複数スラッシュはSplitNで2分割",
+			label:         "a/b/c",
+			wantProfile:   "a",
+			wantWorkspace: "b/c",
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, workspace, err := ParseWorkspaceLabel(tt.label)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseWorkspaceLabel(%q) expected error, got nil", tt.label)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseWorkspaceLabel(%q) unexpected error: %v", tt.label, err)
+				return
+			}
+			if profile != tt.wantProfile {
+				t.Errorf("ParseWorkspaceLabel(%q) profile = %q, want %q", tt.label, profile, tt.wantProfile)
+			}
+			if workspace != tt.wantWorkspace {
+				t.Errorf("ParseWorkspaceLabel(%q) workspace = %q, want %q", tt.label, workspace, tt.wantWorkspace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add 61 test cases across 7 test files covering config, workspace, git, fzf, and ui
- Add Config.AddProfile, AddRepoToProfile, RemoveRepoFromProfile methods
- Add `mgv profile add`, `profile add-repo`, `profile remove-repo` subcommands