### PR TITLE
feat: add profile management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,15 @@ mgv profile list
 
 # プロファイルの詳細表示
 mgv profile show project-a
+
+# 新しいプロファイルを対話的に作成
+mgv profile add
+
+# 既存プロファイルにリポジトリを追加
+mgv profile add-repo project-a
+
+# プロファイルからリポジトリを削除
+mgv profile remove-repo project-a frontend-A
 ```
 
 `profile list` の出力例:
@@ -298,6 +307,9 @@ project-a (default)
 | `mgv status [name]` | fzf でワークスペース選択 | 引数で直接指定 | git status まとめ表示 |
 | `mgv profile list` | - | - | プロファイル一覧 |
 | `mgv profile show <name>` | - | - | プロファイル詳細 |
+| `mgv profile add` | プロファイル名 / リポ選択を対話 | - | プロファイル作成 |
+| `mgv profile add-repo [profile]` | リポ選択を対話 | 引数で直接指定 | リポジトリ追加 |
+| `mgv profile remove-repo [profile] [repo]` | fzf でリポ選択 | 引数で直接指定 | リポジトリ削除 |
 
 ## ディレクトリ構成
 
@@ -347,7 +359,7 @@ mangrove/
 │   ├── cd.go                # mgv cd
 │   ├── exec.go              # mgv exec
 │   ├── status.go            # mgv status
-│   └── profile.go           # mgv profile list / show
+│   └── profile.go           # mgv profile list / show / add / add-repo / remove-repo
 ├── config.go                # 設定読み込み、Profile / Repo 構造体
 ├── git.go                   # git コマンド呼び出しラッパー
 ├── workspace.go             # ワークスペース操作ロジック

--- a/command/profile.go
+++ b/command/profile.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Koutaro-Hanabusa/mangrove"
 	"github.com/spf13/cobra"
@@ -86,8 +89,246 @@ var profileShowCmd = &cobra.Command{
 	},
 }
 
+var profileAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new profile",
+	Long:  "Interactively create a new profile with repositories.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(os.Stdin)
+
+		// Prompt for profile name
+		var profileName string
+		for profileName == "" {
+			profileName = promptInput(reader, "Profile name", "")
+			if profileName == "" {
+				fmt.Fprintln(os.Stderr, "  Profile name is required.")
+			}
+		}
+
+		// Check if profile already exists
+		if _, exists := cfg.Profiles[profileName]; exists {
+			return fmt.Errorf("profile %q already exists", profileName)
+		}
+
+		// Check fzf availability
+		if !mangrove.IsFzfAvailable() {
+			return fmt.Errorf("fzf is required for repository selection. Install it with: brew install fzf")
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+
+		// Loop to add repositories
+		var repos []mangrove.Repo
+		for {
+			fmt.Fprintln(os.Stderr, "? Select repository directory (Esc to finish):")
+			repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+			if err != nil {
+				if strings.Contains(err.Error(), "cancelled") {
+					if len(repos) == 0 {
+						fmt.Fprintln(os.Stderr, "  At least one repository is required.")
+						continue
+					}
+					break
+				}
+				return fmt.Errorf("directory selection failed: %w", err)
+			}
+
+			expandedPath := mangrove.ExpandPath(repoPath)
+
+			if !isGitRepo(expandedPath) {
+				fmt.Fprintf(os.Stderr, "  %s is not a valid git repository.\n", expandedPath)
+				continue
+			}
+
+			repoName := filepath.Base(expandedPath)
+			detectedBranch := mangrove.DetectDefaultBranch(expandedPath)
+
+			fmt.Fprintf(os.Stderr, "  -> Detected: %s (branch: %s)\n", repoName, detectedBranch)
+
+			defaultBase := promptInput(reader, "Default base branch", detectedBranch)
+			if defaultBase == "" {
+				defaultBase = detectedBranch
+			}
+
+			repos = append(repos, mangrove.Repo{
+				Name:        repoName,
+				Path:        expandedPath,
+				DefaultBase: defaultBase,
+			})
+
+			fmt.Fprint(os.Stderr, "? Add another repository? (Y/n): ")
+			if !promptYesNo(reader, true) {
+				break
+			}
+		}
+
+		if len(repos) == 0 {
+			return fmt.Errorf("no repositories added, aborting")
+		}
+
+		profile := mangrove.Profile{
+			Repos: repos,
+		}
+
+		if err := cfg.AddProfile(profileName, profile); err != nil {
+			return err
+		}
+
+		// Ask to set as default profile
+		if cfg.DefaultProfile == "" {
+			fmt.Fprint(os.Stderr, "? Set as default profile? (Y/n): ")
+			if promptYesNo(reader, true) {
+				cfg.DefaultProfile = profileName
+			}
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Added profile %q with %d repo(s)", profileName, len(repos))
+		return nil
+	},
+}
+
+var profileAddRepoCmd = &cobra.Command{
+	Use:   "add-repo [profile-name]",
+	Short: "Add a repository to an existing profile",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(os.Stdin)
+
+		// Resolve profile name
+		var profileName string
+		if len(args) > 0 {
+			profileName = args[0]
+		} else {
+			_, name, err := resolveProfile(true)
+			if err != nil {
+				return err
+			}
+			profileName = name
+		}
+
+		if _, ok := cfg.Profiles[profileName]; !ok {
+			return fmt.Errorf("profile %q not found", profileName)
+		}
+
+		// Check fzf availability
+		if !mangrove.IsFzfAvailable() {
+			return fmt.Errorf("fzf is required for repository selection. Install it with: brew install fzf")
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+
+		// Select repository directory
+		fmt.Fprintln(os.Stderr, "? Select repository directory:")
+		repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+		if err != nil {
+			return fmt.Errorf("directory selection failed: %w", err)
+		}
+
+		expandedPath := mangrove.ExpandPath(repoPath)
+
+		if !isGitRepo(expandedPath) {
+			return fmt.Errorf("%s is not a valid git repository", expandedPath)
+		}
+
+		repoName := filepath.Base(expandedPath)
+		detectedBranch := mangrove.DetectDefaultBranch(expandedPath)
+
+		fmt.Fprintf(os.Stderr, "  -> Detected: %s (branch: %s)\n", repoName, detectedBranch)
+
+		defaultBase := promptInput(reader, "Default base branch", detectedBranch)
+		if defaultBase == "" {
+			defaultBase = detectedBranch
+		}
+
+		repo := mangrove.Repo{
+			Name:        repoName,
+			Path:        expandedPath,
+			DefaultBase: defaultBase,
+		}
+
+		if err := cfg.AddRepoToProfile(profileName, repo); err != nil {
+			return err
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Added repository %q to profile %q", repoName, profileName)
+		return nil
+	},
+}
+
+var profileRemoveRepoCmd = &cobra.Command{
+	Use:   "remove-repo [profile-name] [repo-name]",
+	Short: "Remove a repository from a profile",
+	Args:  cobra.RangeArgs(0, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Resolve profile name
+		var profileName string
+		if len(args) >= 1 {
+			profileName = args[0]
+		} else {
+			_, name, err := resolveProfile(true)
+			if err != nil {
+				return err
+			}
+			profileName = name
+		}
+
+		profile, ok := cfg.Profiles[profileName]
+		if !ok {
+			return fmt.Errorf("profile %q not found", profileName)
+		}
+
+		// Resolve repo name
+		var repoName string
+		if len(args) >= 2 {
+			repoName = args[1]
+		} else {
+			// Let user select from existing repos
+			repoNames := make([]string, len(profile.Repos))
+			for i, r := range profile.Repos {
+				repoNames[i] = r.Name
+			}
+			if len(repoNames) == 0 {
+				return fmt.Errorf("profile %q has no repositories", profileName)
+			}
+			selected, err := mangrove.SelectWithFzf(repoNames, "Remove repo:", "Select repository to remove")
+			if err != nil {
+				return err
+			}
+			repoName = selected
+		}
+
+		if err := cfg.RemoveRepoFromProfile(profileName, repoName); err != nil {
+			return err
+		}
+
+		if err := mangrove.SaveConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+
+		mangrove.PrintSuccess("Removed repository %q from profile %q", repoName, profileName)
+		return nil
+	},
+}
+
 func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileShowCmd)
+	profileCmd.AddCommand(profileAddCmd)
+	profileCmd.AddCommand(profileAddRepoCmd)
+	profileCmd.AddCommand(profileRemoveRepoCmd)
 	rootCmd.AddCommand(profileCmd)
 }


### PR DESCRIPTION
## Summary
- `config.go` に `AddProfile`, `AddRepoToProfile`, `RemoveRepoFromProfile` メソッドを追加
- `mgv profile add` — 対話的にプロファイルを作成（fzf でリポ選択、Git 検証、ブランチ自動検出）
- `mgv profile add-repo [profile-name]` — 既存プロファイルにリポジトリを追加
- `mgv profile remove-repo [profile-name] [repo-name]` — プロファイルからリポジトリを削除
- README に新コマンドのドキュメントを追加

## Test plan
- [ ] `go build ./...` でビルド確認
- [ ] `go vet ./...` で静的解析確認
- [ ] `mgv profile --help` でサブコマンド一覧確認
- [ ] `mgv profile add` で新規プロファイル作成の動作確認
- [ ] `mgv profile add-repo` でリポジトリ追加の動作確認
- [ ] `mgv profile remove-repo` でリポジトリ削除の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)