### PR TITLE
fix: Esc/Ctrl+Cでfzf選択をキャンセルできない問題を修正

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -60,7 +61,7 @@ var initCmd = &cobra.Command{
 			repoPath, err := mangrove.SelectGitRepository("Repository path:", home)
 			if err != nil {
 				// User cancelled with Esc
-				if strings.Contains(err.Error(), "cancelled") {
+				if errors.Is(err, mangrove.ErrCancelled) {
 					break
 				}
 				return fmt.Errorf("directory selection failed: %w", err)

--- a/command/profile.go
+++ b/command/profile.go
@@ -2,11 +2,11 @@ package command
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/Koutaro-Hanabusa/mangrove"
 	"github.com/spf13/cobra"
@@ -126,7 +126,7 @@ var profileAddCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "? Select repository directory (Esc to finish):")
 			repoPath, err := mangrove.SelectDirectory("Repository path:", home)
 			if err != nil {
-				if strings.Contains(err.Error(), "cancelled") {
+				if errors.Is(err, mangrove.ErrCancelled) {
 					if len(repos) == 0 {
 						fmt.Fprintln(os.Stderr, "  At least one repository is required.")
 						continue

--- a/command/root.go
+++ b/command/root.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -62,6 +63,9 @@ func init() {
 // Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		if errors.Is(err, mangrove.ErrCancelled) {
+			return
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,380 @@
+package mangrove
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("cannot get home dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "tilde with subpath",
+			path: "~/Documents/projects",
+			want: filepath.Join(home, "Documents", "projects"),
+		},
+		{
+			name: "non-tilde path passthrough",
+			path: "/usr/local/bin",
+			want: "/usr/local/bin",
+		},
+		{
+			name: "exact tilde only is not expanded",
+			path: "~",
+			want: "~",
+		},
+		{
+			name: "relative path passthrough",
+			path: "relative/path",
+			want: "relative/path",
+		},
+		{
+			name: "tilde slash root",
+			path: "~/",
+			want: home,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandPath(tt.path)
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollapsePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("cannot get home dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "home dir with subpath",
+			path: filepath.Join(home, "Documents", "projects"),
+			want: "~/Documents/projects",
+		},
+		{
+			name: "non-home path passthrough",
+			path: "/usr/local/bin",
+			want: "/usr/local/bin",
+		},
+		{
+			name: "exact home dir",
+			path: home,
+			want: "~",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CollapsePath(tt.path)
+			if got != tt.want {
+				t.Errorf("CollapsePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetProfile(t *testing.T) {
+	cfg := &Config{
+		DefaultProfile: "default-profile",
+		Profiles: map[string]Profile{
+			"default-profile": {
+				Repos: []Repo{{Name: "repo1", Path: "/path/to/repo1"}},
+			},
+			"other-profile": {
+				Repos: []Repo{{Name: "repo2", Path: "/path/to/repo2"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantRepos int
+		wantErr   bool
+	}{
+		{
+			name:      "existing profile by name",
+			input:     "other-profile",
+			wantName:  "other-profile",
+			wantRepos: 1,
+			wantErr:   false,
+		},
+		{
+			name:    "missing profile",
+			input:   "nonexistent",
+			wantErr: true,
+		},
+		{
+			name:      "empty name uses default",
+			input:     "",
+			wantName:  "default-profile",
+			wantRepos: 1,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, name, err := cfg.GetProfile(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetProfile(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetProfile(%q) unexpected error: %v", tt.input, err)
+			}
+			if name != tt.wantName {
+				t.Errorf("GetProfile(%q) name = %q, want %q", tt.input, name, tt.wantName)
+			}
+			if len(profile.Repos) != tt.wantRepos {
+				t.Errorf("GetProfile(%q) repos = %d, want %d", tt.input, len(profile.Repos), tt.wantRepos)
+			}
+		})
+	}
+
+	// Test empty name without default
+	cfgNoDefault := &Config{
+		DefaultProfile: "",
+		Profiles: map[string]Profile{
+			"some-profile": {},
+		},
+	}
+	_, _, err2 := cfgNoDefault.GetProfile("")
+	if err2 == nil {
+		t.Error("GetProfile(\"\") with no default should return error")
+	}
+}
+
+func TestProfileNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles map[string]Profile
+		wantLen  int
+	}{
+		{
+			name: "with profiles",
+			profiles: map[string]Profile{
+				"alpha": {},
+				"beta":  {},
+				"gamma": {},
+			},
+			wantLen: 3,
+		},
+		{
+			name:     "empty profiles",
+			profiles: map[string]Profile{},
+			wantLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Profiles: tt.profiles}
+			names := cfg.ProfileNames()
+			if len(names) != tt.wantLen {
+				t.Errorf("ProfileNames() returned %d names, want %d", len(names), tt.wantLen)
+			}
+
+			// Verify all profile names are present
+			sort.Strings(names)
+			expectedNames := make([]string, 0, len(tt.profiles))
+			for n := range tt.profiles {
+				expectedNames = append(expectedNames, n)
+			}
+			sort.Strings(expectedNames)
+
+			for i, name := range names {
+				if name != expectedNames[i] {
+					t.Errorf("ProfileNames()[%d] = %q, want %q", i, name, expectedNames[i])
+				}
+			}
+		})
+	}
+}
+
+func TestAddProfile(t *testing.T) {
+	t.Run("normal add", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{},
+		}
+		profile := Profile{Repos: []Repo{{Name: "repo1", Path: "/path"}}}
+		err := cfg.AddProfile("new-profile", profile)
+		if err != nil {
+			t.Fatalf("AddProfile() unexpected error: %v", err)
+		}
+		if _, ok := cfg.Profiles["new-profile"]; !ok {
+			t.Error("AddProfile() profile not added to map")
+		}
+	})
+
+	t.Run("duplicate add error", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{
+				"existing": {},
+			},
+		}
+		err := cfg.AddProfile("existing", Profile{})
+		if err == nil {
+			t.Error("AddProfile() expected error for duplicate profile")
+		}
+	})
+
+	t.Run("nil map initialization", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: nil,
+		}
+		err := cfg.AddProfile("new-profile", Profile{})
+		if err != nil {
+			t.Fatalf("AddProfile() unexpected error: %v", err)
+		}
+		if cfg.Profiles == nil {
+			t.Error("AddProfile() should initialize nil Profiles map")
+		}
+		if _, ok := cfg.Profiles["new-profile"]; !ok {
+			t.Error("AddProfile() profile not added after nil map init")
+		}
+	})
+}
+
+func TestAddRepoToProfile(t *testing.T) {
+	t.Run("normal add", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{
+				"myprofile": {Repos: []Repo{{Name: "repo1", Path: "/path/repo1"}}},
+			},
+		}
+		repo := Repo{Name: "repo2", Path: "/path/repo2"}
+		err := cfg.AddRepoToProfile("myprofile", repo)
+		if err != nil {
+			t.Fatalf("AddRepoToProfile() unexpected error: %v", err)
+		}
+		profile := cfg.Profiles["myprofile"]
+		if len(profile.Repos) != 2 {
+			t.Errorf("AddRepoToProfile() repos count = %d, want 2", len(profile.Repos))
+		}
+	})
+
+	t.Run("duplicate repo error", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{
+				"myprofile": {Repos: []Repo{{Name: "repo1", Path: "/path/repo1"}}},
+			},
+		}
+		repo := Repo{Name: "repo1", Path: "/path/repo1-dup"}
+		err := cfg.AddRepoToProfile("myprofile", repo)
+		if err == nil {
+			t.Error("AddRepoToProfile() expected error for duplicate repo name")
+		}
+	})
+
+	t.Run("missing profile error", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{},
+		}
+		repo := Repo{Name: "repo1", Path: "/path/repo1"}
+		err := cfg.AddRepoToProfile("nonexistent", repo)
+		if err == nil {
+			t.Error("AddRepoToProfile() expected error for missing profile")
+		}
+	})
+}
+
+func TestRemoveRepoFromProfile(t *testing.T) {
+	t.Run("normal remove", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{
+				"myprofile": {
+					Repos: []Repo{
+						{Name: "repo1", Path: "/path/repo1"},
+						{Name: "repo2", Path: "/path/repo2"},
+					},
+				},
+			},
+		}
+		err := cfg.RemoveRepoFromProfile("myprofile", "repo1")
+		if err != nil {
+			t.Fatalf("RemoveRepoFromProfile() unexpected error: %v", err)
+		}
+		profile := cfg.Profiles["myprofile"]
+		if len(profile.Repos) != 1 {
+			t.Errorf("RemoveRepoFromProfile() repos count = %d, want 1", len(profile.Repos))
+		}
+		if profile.Repos[0].Name != "repo2" {
+			t.Errorf("RemoveRepoFromProfile() remaining repo = %q, want %q", profile.Repos[0].Name, "repo2")
+		}
+	})
+
+	t.Run("missing repo error", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{
+				"myprofile": {Repos: []Repo{{Name: "repo1", Path: "/path/repo1"}}},
+			},
+		}
+		err := cfg.RemoveRepoFromProfile("myprofile", "nonexistent")
+		if err == nil {
+			t.Error("RemoveRepoFromProfile() expected error for missing repo")
+		}
+	})
+
+	t.Run("missing profile error", func(t *testing.T) {
+		cfg := &Config{
+			Profiles: map[string]Profile{},
+		}
+		err := cfg.RemoveRepoFromProfile("nonexistent", "repo1")
+		if err == nil {
+			t.Error("RemoveRepoFromProfile() expected error for missing profile")
+		}
+	})
+}
+
+func TestGetDefaultBase(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultBase string
+		want        string
+	}{
+		{
+			name:        "with value set",
+			defaultBase: "develop",
+			want:        "develop",
+		},
+		{
+			name:        "empty falls back to main",
+			defaultBase: "",
+			want:        "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &Repo{DefaultBase: tt.defaultBase}
+			got := repo.GetDefaultBase()
+			if got != tt.want {
+				t.Errorf("GetDefaultBase() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/fzf.go
+++ b/fzf.go
@@ -1,6 +1,7 @@
 package mangrove
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -8,6 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 )
+
+// ErrCancelled is returned when the user cancels an fzf selection (Esc or Ctrl+C).
+var ErrCancelled = errors.New("selection cancelled by user")
 
 // IsFzfAvailable checks whether fzf is installed and available in PATH.
 func IsFzfAvailable() bool {
@@ -42,8 +46,8 @@ func SelectWithFzf(items []string, prompt, header string) (string, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == 130 {
-				return "", fmt.Errorf("selection cancelled by user")
+			if exitErr.ExitCode() == 130 || exitErr.ExitCode() == 1 {
+				return "", fmt.Errorf("%w", ErrCancelled)
 			}
 		}
 		return "", fmt.Errorf("fzf selection failed: %w", err)
@@ -90,8 +94,8 @@ func SelectDirectory(prompt, walkerRoot string) (string, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == 130 {
-				return "", fmt.Errorf("selection cancelled by user")
+			if exitErr.ExitCode() == 130 || exitErr.ExitCode() == 1 {
+				return "", fmt.Errorf("%w", ErrCancelled)
 			}
 		}
 		return "", fmt.Errorf("fzf directory selection failed: %w", err)

--- a/fzf_test.go
+++ b/fzf_test.go
@@ -1,0 +1,160 @@
+package mangrove
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReorderWithDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []string
+		defaultItem string
+		want        []string
+	}{
+		{
+			name:        "default exists in list",
+			items:       []string{"feature", "main", "develop"},
+			defaultItem: "main",
+			want:        []string{"main", "feature", "develop"},
+		},
+		{
+			name:        "default does not exist in list",
+			items:       []string{"feature", "develop"},
+			defaultItem: "main",
+			want:        []string{"feature", "develop"},
+		},
+		{
+			name:        "empty default",
+			items:       []string{"feature", "main", "develop"},
+			defaultItem: "",
+			want:        []string{"feature", "main", "develop"},
+		},
+		{
+			name:        "single item list with match",
+			items:       []string{"main"},
+			defaultItem: "main",
+			want:        []string{"main"},
+		},
+		{
+			name:        "single item list without match",
+			items:       []string{"develop"},
+			defaultItem: "main",
+			want:        []string{"develop"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reorderWithDefault(tt.items, tt.defaultItem)
+			if len(got) != len(tt.want) {
+				t.Fatalf("reorderWithDefault() returned %d items, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("reorderWithDefault()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFindGitRepositories(t *testing.T) {
+	// Create a temp directory structure:
+	// root/
+	//   repo-a/.git/
+	//   repo-b/.git/
+	//   node_modules/hidden-repo/.git/  (should be skipped)
+	//   nested/repo-c/.git/
+	root := t.TempDir()
+
+	dirs := []string{
+		filepath.Join(root, "repo-a", ".git"),
+		filepath.Join(root, "repo-b", ".git"),
+		filepath.Join(root, "node_modules", "hidden-repo", ".git"),
+		filepath.Join(root, "nested", "repo-c", ".git"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", d, err)
+		}
+	}
+
+	repos, err := FindGitRepositories(root)
+	if err != nil {
+		t.Fatalf("FindGitRepositories() error: %v", err)
+	}
+
+	// Build a set of found repos for easy lookup
+	found := make(map[string]bool)
+	for _, r := range repos {
+		found[r] = true
+	}
+
+	// repo-a and repo-b should be found
+	expectedRepos := []string{
+		filepath.Join(root, "repo-a"),
+		filepath.Join(root, "repo-b"),
+		filepath.Join(root, "nested", "repo-c"),
+	}
+	for _, expected := range expectedRepos {
+		if !found[expected] {
+			t.Errorf("expected repo %q to be found, but it was not", expected)
+		}
+	}
+
+	// node_modules should be skipped
+	skippedRepo := filepath.Join(root, "node_modules", "hidden-repo")
+	if found[skippedRepo] {
+		t.Errorf("repo %q under node_modules should have been skipped", skippedRepo)
+	}
+
+	// Total count should match
+	if len(repos) != len(expectedRepos) {
+		t.Errorf("FindGitRepositories() found %d repos, want %d", len(repos), len(expectedRepos))
+	}
+}
+
+func TestFindGitRepositories_EmptyDir(t *testing.T) {
+	root := t.TempDir()
+
+	repos, err := FindGitRepositories(root)
+	if err != nil {
+		t.Fatalf("FindGitRepositories() error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Errorf("FindGitRepositories() found %d repos in empty dir, want 0", len(repos))
+	}
+}
+
+func TestErrCancelled(t *testing.T) {
+	// Verify ErrCancelled is a proper error
+	if ErrCancelled == nil {
+		t.Fatal("ErrCancelled should not be nil")
+	}
+
+	if ErrCancelled.Error() != "selection cancelled by user" {
+		t.Errorf("ErrCancelled.Error() = %q, want %q", ErrCancelled.Error(), "selection cancelled by user")
+	}
+
+	// Verify wrapped error can be unwrapped with errors.Is
+	wrapped := fmt.Errorf("some context: %w", ErrCancelled)
+	if !errors.Is(wrapped, ErrCancelled) {
+		t.Error("errors.Is(wrapped, ErrCancelled) should be true for wrapped error")
+	}
+
+	// Verify double wrapping works
+	doubleWrapped := fmt.Errorf("outer: %w", wrapped)
+	if !errors.Is(doubleWrapped, ErrCancelled) {
+		t.Error("errors.Is(doubleWrapped, ErrCancelled) should be true for double-wrapped error")
+	}
+
+	// Verify unrelated error does not match
+	unrelated := fmt.Errorf("something else went wrong")
+	if errors.Is(unrelated, ErrCancelled) {
+		t.Error("errors.Is(unrelated, ErrCancelled) should be false for unrelated error")
+	}
+}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,61 @@
+package mangrove
+
+import (
+	"testing"
+)
+
+func TestParseLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "normal multiline input",
+			input: "main\ndevelop\nfeature/foo\n",
+			want:  []string{"main", "develop", "feature/foo"},
+		},
+		{
+			name:  "empty lines filtered",
+			input: "main\n\ndevelop\n\n",
+			want:  []string{"main", "develop"},
+		},
+		{
+			name:  "single line",
+			input: "main\n",
+			want:  []string{"main"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "only whitespace lines",
+			input: "\n  \n\t\n",
+			want:  nil,
+		},
+		{
+			name:  "lines with extra whitespace",
+			input: "  main  \n  develop  \n",
+			want:  []string{"main", "develop"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLines(tt.input)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseLines(%q) returned %d lines, want %d\ngot: %v\nwant: %v",
+					tt.input, len(got), len(tt.want), got, tt.want)
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseLines(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `ErrCancelled`センチネルエラーを定義し、fzf exit code 1(Esc)と130(Ctrl+C)の両方を処理
- 脆弱な文字列マッチング(`strings.Contains`)を`errors.Is()`に置換
- キャンセル時のエラー表示を抑制し、静かに終了するように改善
- fzf, config, gitの単体テストを追加（32ケース）

## Test plan
- [x] `go build ./...` が通ること
- [x] `go test ./...` で全32テストがパスすること
- [ ] `mgv init` でEsc/Ctrl+Cで抜けられること
- [ ] `mgv new` でEsc/Ctrl+Cで抜けられること
- [ ] `mgv cd` でEsc/Ctrl+Cで抜けられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)