### PR TITLE
fix: fzf ESCキャンセル対応・dir-only・profile選択修正

### DIFF
--- a/command/profile.go
+++ b/command/profile.go
@@ -124,7 +124,7 @@ var profileAddCmd = &cobra.Command{
 		var repos []mangrove.Repo
 		for {
 			fmt.Fprintln(os.Stderr, "? Select repository directory (Esc to finish):")
-			repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+			repoPath, err := mangrove.SelectGitRepository("Repository path:", home)
 			if err != nil {
 				if errors.Is(err, mangrove.ErrCancelled) {
 					if len(repos) == 0 {
@@ -229,7 +229,7 @@ var profileAddRepoCmd = &cobra.Command{
 
 		// Select repository directory
 		fmt.Fprintln(os.Stderr, "? Select repository directory:")
-		repoPath, err := mangrove.SelectDirectory("Repository path:", home)
+		repoPath, err := mangrove.SelectGitRepository("Repository path:", home)
 		if err != nil {
 			return fmt.Errorf("directory selection failed: %w", err)
 		}

--- a/fzf.go
+++ b/fzf.go
@@ -77,7 +77,7 @@ func SelectDirectory(prompt, walkerRoot string) (string, error) {
 	}
 
 	args := []string{
-		"--walker=dir,hidden",
+		"--walker=dir",
 		"--walker-root=" + walkerRoot,
 		"--scheme=path",
 		"--height", "~40%",


### PR DESCRIPTION
## Summary
- fzfでESC (exit code 1) を押した際にキャンセルとして正しく処理されるように修正
- `--walker=dir,hidden` → `--walker=dir` に変更し、隠しディレクトリを表示しないように修正
- `profile add` / `profile add-repo` で `SelectDirectory` の代わりに `SelectGitRepository` を使用し、gitリポジトリのみ選択可能に統一

## Changes
| ファイル | 変更内容 |
|---|---|
| `fzf.go` | ESC (exit code 1) をキャンセルとして処理、`--walker=dir` のみに変更 |
| `command/profile.go` | `SelectDirectory` → `SelectGitRepository` に変更 (L127, L232) |
| `fzf_test.go` | ユニットテスト13件を新規追加 |

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./...` 全13テストパス
- [x] ESC (exit code 1) で `"selection cancelled by user"` が返ることを確認
- [x] Ctrl+C (exit code 130) で `"selection cancelled by user"` が返ることを確認
- [x] exit code 2 で `"fzf selection failed"` が返ることを確認
- [x] `--walker=dir` のみが渡されることを確認（`hidden` なし）
- [x] `init` / `profile add` / `profile add-repo` 全てが `SelectGitRepository` を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)